### PR TITLE
respect filesystem standard locations

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -5,7 +5,7 @@ access_token=UserAccessToken
 access_token_secret=UserAccessTokenSecret
 
 [cache]
-cachefile=cache.dat
+cachefile=~/.cache/feed2tweet.dat
 
 [rss]
 uri=http://example.com/feed.xml

--- a/feed2tweet
+++ b/feed2tweet
@@ -58,7 +58,7 @@ def main():
     """The main function."""
     global config
     parser = OptionParser(version='%prog v' + __version__)
-    parser.add_option('-c', '--config', default='config.ini',
+    parser.add_option('-c', '--config', default='~/.config/feed2tweet.ini',
                       help='Location of config file (default: %default)',
                       metavar='FILE')
     parser.add_option('-a', '--all', action='store_true', default=False,
@@ -69,10 +69,10 @@ def main():
                       help='Use with all parameters, send the first 10 feeds as a tweet')
     (options, args) = parser.parse_args()
     config = SafeConfigParser()
-    if not config.read(options.config):
+    if not config.read(os.path.expanduser(options.config)):
         print 'Could not read config file'
         sys.exit(1)
-    cachefile = config.get('cache', 'cachefile')
+    cachefile = os.path.expanduser(config.get('cache', 'cachefile'))
     rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(rss_uri)
     severalwordshashtagfile = config.get('hashtaglist', 'several_words_hashtags_list')

--- a/feed2tweet
+++ b/feed2tweet
@@ -58,7 +58,8 @@ def main():
     """The main function."""
     global config
     parser = OptionParser(version='%prog v' + __version__)
-    parser.add_option('-c', '--config', default='~/.config/feed2tweet.ini',
+    parser.add_option('-c', '--config',
+                      default=os.getenv('XDG_CONFIG_HOME', '~/.config/feed2tweet.ini'),
                       help='Location of config file (default: %default)',
                       metavar='FILE')
     parser.add_option('-a', '--all', action='store_true', default=False,
@@ -72,7 +73,7 @@ def main():
     if not config.read(os.path.expanduser(options.config)):
         print 'Could not read config file'
         sys.exit(1)
-    cachefile = os.path.expanduser(config.get('cache', 'cachefile'))
+    cachefile = os.path.expanduser(os.getenv('XDG_CACHE_HOME', config.get('cache', 'cachefile')))
     rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(rss_uri)
     severalwordshashtagfile = config.get('hashtaglist', 'several_words_hashtags_list')


### PR DESCRIPTION
there could be better locations for this, but then those would need to be lists of locations(for example to include `/etc`), which is more annoying to implement. this scratches my particular itch and respects the standards a little more.

see also:

http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables