### PR TITLE
Refactor

### DIFF
--- a/feed2tweet
+++ b/feed2tweet
@@ -68,7 +68,14 @@ def main():
     parser.add_argument('-n', '--dry-run', dest='dryrun',
                         action='store_true', default=False,
                         help='Do not actually post tweets')
+    parser.add_argument('-v', '--verbose', '--info', dest='log_level',
+                        action='store_const', const='info', default='warning',
+                        help='enable informative (verbose) output, work on log level INFO')
+    parser.add_argument('-d', '--debug', dest='log_level',
+                        action='store_const', const='debug', default='warning',
+                        help='enable debug output, work on log level DEBUG')
     options = parser.parse_args()
+    logging.basicConfig(level=options.log_level.upper(), format='%(message)s')
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
         sys.exit('Could not read config file')
@@ -132,7 +139,6 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG, format='%(message)s')
     try:
         main()
     except KeyboardInterrupt as e:

--- a/feed2tweet
+++ b/feed2tweet
@@ -88,8 +88,7 @@ def main():
     severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
     entries = feed['entries'][0:options.limit]
 
-    cached = False
-    for entry in entries:
+    for entry in reversed(entries):
         if not options.all and entry['id'] == cache['id']:
             break
 
@@ -118,10 +117,7 @@ def main():
         else:
             post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
 
-            # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
-            if not cached:
-                cPickle.dump(rss, open(cachefile, 'wb'), -1)
-                cached = True
+            cPickle.dump(rss, open(cachefile, 'wb'), -1)
 
 
 if __name__ == "__main__":

--- a/feed2tweet
+++ b/feed2tweet
@@ -100,7 +100,9 @@ def main():
 
     cached = False
     for entry in entries:
+        logging.debug('found feed entry %s, %s', entry['id'], entry['title'])
         if not options.all and entry['id'] == cache['id']:
+            logging.debug('found known entry, stopped processing')
             break
 
         rss = {

--- a/feed2tweet
+++ b/feed2tweet
@@ -32,6 +32,7 @@ __version__ = '0.1'
 
 config = None
 
+
 def post_update(status):
     global config
     consumer_key = config.get('twitter', 'consumer_key')
@@ -55,14 +56,15 @@ def main():
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('-c', '--config',
-                        default=os.getenv('XDG_CONFIG_HOME', '~/.config/feed2tweet.ini'),
+                        default=os.getenv('XDG_CONFIG_HOME',
+                                          '~/.config/feed2tweet.ini'),
                         help='Location of config file (default: %(default)s)',
                         metavar='FILE')
     parser.add_argument('-a', '--all', action='store_true', default=False,
                         dest='all',
                         help='tweet all RSS items, regardless of cache')
     parser.add_argument('-l', '--limit', dest='limit', default=10,
-                        help='tweet the first LIMIT feed items (default: %(default)s)')
+                        help='tweet only LIMIT items (default: %(default)s)')
     parser.add_argument('-n', '--dry-run', dest='dryrun',
                         action='store_true', default=False,
                         help='Do not actually post tweets')
@@ -70,11 +72,13 @@ def main():
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
         sys.exit('Could not read config file')
-    cachefile = os.path.expanduser(os.getenv('XDG_CACHE_HOME', config.get('cache', 'cachefile')))
+    cachefile = os.path.expanduser(os.getenv('XDG_CACHE_HOME',
+                                             config.get('cache', 'cachefile')))
     rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(rss_uri)
-    severalwordshashtagfile = config.get('hashtaglist', 'several_words_hashtags_list')
-    
+    severalwordshashtagfile = config.get('hashtaglist',
+                                         'several_words_hashtags_list')
+
     # lots of scary warnings about possible security risk using this method
     # but for local use I'd rather do this than a try-catch with open()
     if not os.path.isfile(cachefile):
@@ -82,7 +86,8 @@ def main():
         cPickle.dump({'id': None}, open(cachefile, 'wb'), -1)
 
     cache = cPickle.load(open(cachefile))
-    severalwordshashtags = codecs.open(severalwordshashtagfile, encoding='utf-8').readlines()
+    severalwordshashtags = codecs.open(severalwordshashtagfile,
+                                       encoding='utf-8').readlines()
     severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
     entries = feed['entries'][0:options.limit]
 
@@ -103,7 +108,8 @@ def main():
         for element in severalwordshashtags:
             if element in prehashtags:
                 severalwordsinhashtag = True
-                tmphashtags = prehashtags.replace(element, ''.join(element.split()))
+                tmphashtags = prehashtags.replace(element,
+                                                  ''.join(element.split()))
         if severalwordsinhashtag:
             tmphashtags = tmphashtags.replace("'", "")
             finalhashtags = tmphashtags.split(' ')
@@ -112,11 +118,14 @@ def main():
         else:
             rss['hashtag'] = ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]])
         if options.dryrun:
-            logging.warning('would post %s %s %s', rss['title'], rss['link'], rss['hashtag'])
+            logging.warning('would post %s %s %s',
+                            rss['title'], rss['link'], rss['hashtag'])
         else:
-            post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
+            post_update('%s %s %s'
+                        % (rss['title'], rss['link'], rss['hashtag']))
 
-            # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
+            # We keep the first feed in the cache, to use feed2tweet
+            # in normal mode the next time
             if not cached:
                 cPickle.dump(rss, open(cachefile, 'wb'), -1)
                 cached = True

--- a/feed2tweet
+++ b/feed2tweet
@@ -14,11 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-"""Checks rss feed and posts to twitter.
-
-Check an rss feed and if the latest entry is different than post it to twitter.
-
-"""
+"""Checks an RSS feed and posts new entries to twitter."""
 
 import codecs
 import sys
@@ -64,13 +60,13 @@ def main():
                       metavar='FILE')
     parser.add_option('-a', '--all', action='store_true', default=False,
                       dest='all',
-                      help='Send all RSS items as tweet')
-    parser.add_option('-l', '--limit', dest='limit',
-                      default=10,
-                      help='Use with all parameters, send the first 10 feeds as a tweet')
+                      help='tweet all RSS items, regardless of cache')
+    parser.add_option('-l', '--limit', dest='limit', default=10,
+                      help='tweet the first LIMIT feed items (default: %default)')
     parser.add_option('-n', '--dry-run', dest='dryrun',
                       action='store_true', default=False,
                       help='Do not actually post tweets')
+    parser.epilog = __doc__
     (options, args) = parser.parse_args()
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
@@ -90,14 +86,13 @@ def main():
     cache = cPickle.load(open(cachefile))
     severalwordshashtags = codecs.open(severalwordshashtagfile, encoding='utf-8').readlines()
     severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
-    if options.all:
-        entries = feed[entries]
-    else:
-        # XXX: this should respect --limit
-        entries = feed[entries][0:1]
+    entries = feed['entries'][0:options.limit]
 
-    tweet_count = 0
-    for entry in feed['entries']:
+    cached = False
+    for entry in entries:
+        if not options.all and entry['id'] == cache['id']:
+            break
+
         severalwordsinhashtag = False
         prehashtags = entry['tags'][0]['term']
         tmphashtags = entry['tags'][0]['term']
@@ -130,12 +125,9 @@ def main():
             post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
 
             # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
-            if tweet_count == 0:
+            if not cached:
                 cPickle.dump(rss, open(cachefile, 'wb'), -1)
-
-        tweet_count += 1
-        if tweet_count >= options.limit:
-            break
+                cached = True
 
 
 if __name__ == "__main__":

--- a/feed2tweet
+++ b/feed2tweet
@@ -22,7 +22,7 @@ import sys
 import os
 import cPickle
 from ConfigParser import SafeConfigParser
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 import feedparser
 import tweepy
@@ -52,21 +52,21 @@ def post_update(status):
 def main():
     """The main function."""
     global config
-    parser = OptionParser(version='%prog v' + __version__)
-    parser.add_option('-c', '--config',
-                      default=os.getenv('XDG_CONFIG_HOME', '~/.config/feed2tweet.ini'),
-                      help='Location of config file (default: %default)',
-                      metavar='FILE')
-    parser.add_option('-a', '--all', action='store_true', default=False,
-                      dest='all',
-                      help='tweet all RSS items, regardless of cache')
-    parser.add_option('-l', '--limit', dest='limit', default=10,
-                      help='tweet the first LIMIT feed items (default: %default)')
-    parser.add_option('-n', '--dry-run', dest='dryrun',
-                      action='store_true', default=False,
-                      help='Do not actually post tweets')
-    parser.epilog = __doc__
-    (options, args) = parser.parse_args()
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('--version', action='version', version=__version__)
+    parser.add_argument('-c', '--config',
+                        default=os.getenv('XDG_CONFIG_HOME', '~/.config/feed2tweet.ini'),
+                        help='Location of config file (default: %(default)s)',
+                        metavar='FILE')
+    parser.add_argument('-a', '--all', action='store_true', default=False,
+                        dest='all',
+                        help='tweet all RSS items, regardless of cache')
+    parser.add_argument('-l', '--limit', dest='limit', default=10,
+                        help='tweet the first LIMIT feed items (default: %(default)s)')
+    parser.add_argument('-n', '--dry-run', dest='dryrun',
+                        action='store_true', default=False,
+                        help='Do not actually post tweets')
+    options = parser.parse_args()
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
         sys.exit('Could not read config file')

--- a/feed2tweet
+++ b/feed2tweet
@@ -67,6 +67,9 @@ def main():
     parser.add_option('-l', '--limit', dest='limit',
                       default=10,
                       help='Use with all parameters, send the first 10 feeds as a tweet')
+    parser.add_option('-n', '--dry-run', dest='dryrun',
+                      action='store_true', default=False,
+                      help='Do not actually post tweets')
     (options, args) = parser.parse_args()
     config = SafeConfigParser()
     if not config.read(options.config):
@@ -115,7 +118,10 @@ def main():
                     'summary': entry['summary'],
                     'hashtag': ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]]),
                 }
-            post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
+            if options.dryrun:
+                print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
+            else:
+                post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
 
             # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
             if tweet_count == 0:
@@ -154,8 +160,11 @@ def main():
         # compare with cache
         if cache['id'] != rss['id']:
             #print 'new post'
-            post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
-            cPickle.dump(rss, open(cachefile, 'wb'), -1)
+            if options.dryrun:
+                print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
+            else:
+                post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
+                cPickle.dump(rss, open(cachefile, 'wb'), -1)
 
 
 if __name__ == "__main__":

--- a/feed2tweet
+++ b/feed2tweet
@@ -91,50 +91,16 @@ def main():
     severalwordshashtags = codecs.open(severalwordshashtagfile, encoding='utf-8').readlines()
     severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
     if options.all:
-        tweet_count = 0
-        for entry in feed['entries']:
-            severalwordsinhashtag = False
-            prehashtags = entry['tags'][0]['term']
-            tmphashtags = entry['tags'][0]['term']
-            for element in severalwordshashtags:
-                if element in prehashtags:
-                    severalwordsinhashtag = True
-                    tmphashtags = prehashtags.replace(element, ''.join(element.split()))
-            if severalwordsinhashtag:
-                tmphashtags = tmphashtags.replace("'", "")
-                finalhashtags = tmphashtags.split(' ')
-                rss = {
-                    'id': entry['id'],
-                    'link': entry['link'],
-                    'title': entry['title'],
-                    'summary': entry['summary'],
-                    # issue with splitting hashtags in 2 words is right there
-                    'hashtag': ' '.join(['#%s' % i for i in finalhashtags]),
-                }
-            else:
-                rss = {
-                    'id': entry['id'],
-                    'link': entry['link'],
-                    'title': entry['title'],
-                    'summary': entry['summary'],
-                    'hashtag': ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]]),
-                }
-            if options.dryrun:
-                print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
-            else:
-                post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
-
-            # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
-            if tweet_count == 0:
-                cPickle.dump(rss, open(cachefile, 'wb'), -1)
-
-            tweet_count += 1
-            if tweet_count >= options.limit:
-                break
+        entries = feed[entries]
     else:
+        # XXX: this should respect --limit
+        entries = feed[entries][0:1]
+
+    tweet_count = 0
+    for entry in feed['entries']:
         severalwordsinhashtag = False
-        prehashtags = feed['entries'][0]['tags'][0]['term']
-        tmphashtags = feed['entries'][0]['tags'][0]['term']
+        prehashtags = entry['tags'][0]['term']
+        tmphashtags = entry['tags'][0]['term']
         for element in severalwordshashtags:
             if element in prehashtags:
                 severalwordsinhashtag = True
@@ -143,29 +109,33 @@ def main():
             tmphashtags = tmphashtags.replace("'", "")
             finalhashtags = tmphashtags.split(' ')
             rss = {
-                'id': feed['entries'][0]['id'],
-                'link': feed['entries'][0]['link'],
-                'title': feed['entries'][0]['title'],
-                'summary': feed['entries'][0]['summary'],
+                'id': entry['id'],
+                'link': entry['link'],
+                'title': entry['title'],
+                'summary': entry['summary'],
                 # issue with splitting hashtags in 2 words is right there
                 'hashtag': ' '.join(['#%s' % i for i in finalhashtags]),
             }
         else:
             rss = {
-                'id': feed['entries'][0]['id'],
-                'link': feed['entries'][0]['link'],
-                'title': feed['entries'][0]['title'],
-                'summary': feed['entries'][0]['summary'],
-                'hashtag': ' '.join(['#%s' % i for i in feed['entries'][0]['tags'][0]['term'].split()[:2]]),
+                'id': entry['id'],
+                'link': entry['link'],
+                'title': entry['title'],
+                'summary': entry['summary'],
+                'hashtag': ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]]),
             }
-        # compare with cache
-        if cache['id'] != rss['id']:
-            #print 'new post'
-            if options.dryrun:
-                print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
-            else:
-                post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
+        if options.dryrun:
+            print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
+        else:
+            post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
+
+            # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
+            if tweet_count == 0:
                 cPickle.dump(rss, open(cachefile, 'wb'), -1)
+
+        tweet_count += 1
+        if tweet_count >= options.limit:
+            break
 
 
 if __name__ == "__main__":

--- a/feed2tweet
+++ b/feed2tweet
@@ -16,13 +16,13 @@
 
 """Checks an RSS feed and posts new entries to twitter."""
 
-import codecs
-import logging
-import sys
-import os
-import cPickle
 from ConfigParser import SafeConfigParser
 from argparse import ArgumentParser
+import cPickle
+import codecs
+import logging
+import os
+import sys
 
 import feedparser
 import tweepy

--- a/feed2tweet
+++ b/feed2tweet
@@ -93,6 +93,12 @@ def main():
         if not options.all and entry['id'] == cache['id']:
             break
 
+        rss = {
+            'id': entry['id'],
+            'link': entry['link'],
+            'title': entry['title'],
+            'summary': entry['summary'],
+        }
         severalwordsinhashtag = False
         prehashtags = entry['tags'][0]['term']
         tmphashtags = entry['tags'][0]['term']
@@ -103,22 +109,10 @@ def main():
         if severalwordsinhashtag:
             tmphashtags = tmphashtags.replace("'", "")
             finalhashtags = tmphashtags.split(' ')
-            rss = {
-                'id': entry['id'],
-                'link': entry['link'],
-                'title': entry['title'],
-                'summary': entry['summary'],
-                # issue with splitting hashtags in 2 words is right there
-                'hashtag': ' '.join(['#%s' % i for i in finalhashtags]),
-            }
+            # issue with splitting hashtags in 2 words is right there
+            rss['hashtag'] = ' '.join(['#%s' % i for i in finalhashtags])
         else:
-            rss = {
-                'id': entry['id'],
-                'link': entry['link'],
-                'title': entry['title'],
-                'summary': entry['summary'],
-                'hashtag': ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]]),
-            }
+            rss['hashtag'] = ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]])
         if options.dryrun:
             print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
         else:

--- a/feed2tweet
+++ b/feed2tweet
@@ -88,7 +88,8 @@ def main():
     severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
     entries = feed['entries'][0:options.limit]
 
-    for entry in reversed(entries):
+    cached = False
+    for entry in entries:
         if not options.all and entry['id'] == cache['id']:
             break
 
@@ -117,7 +118,10 @@ def main():
         else:
             post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
 
-            cPickle.dump(rss, open(cachefile, 'wb'), -1)
+            # We keep the first feed in the cache, to use feed2tweet in normal mode the next time
+            if not cached:
+                cPickle.dump(rss, open(cachefile, 'wb'), -1)
+                cached = True
 
 
 if __name__ == "__main__":

--- a/feed2tweet
+++ b/feed2tweet
@@ -17,9 +17,9 @@
 """Checks an RSS feed and posts new entries to twitter."""
 
 import codecs
+import logging
 import sys
 import os
-import traceback
 import cPickle
 from ConfigParser import SafeConfigParser
 from optparse import OptionParser
@@ -44,8 +44,7 @@ def post_update(status):
     try:
         api.update_status(status)
     except tweepy.error.TweepError, e:
-        print "Error occurred while updating status:", e
-        sys.exit(1)
+        logging.warning("Error occurred while updating status: %s", e)
     else:
         return True
 
@@ -70,8 +69,7 @@ def main():
     (options, args) = parser.parse_args()
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
-        print 'Could not read config file'
-        sys.exit(1)
+        sys.exit('Could not read config file')
     cachefile = os.path.expanduser(os.getenv('XDG_CACHE_HOME', config.get('cache', 'cachefile')))
     rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(rss_uri)
@@ -114,7 +112,7 @@ def main():
         else:
             rss['hashtag'] = ' '.join(['#%s' % i for i in entry['tags'][0]['term'].split()[:2]])
         if options.dryrun:
-            print 'would post %s %s %s' % (rss['title'], rss['link'], rss['hashtag'])
+            logging.warning('would post %s %s %s', rss['title'], rss['link'], rss['hashtag'])
         else:
             post_update('%s %s %s' % (rss['title'], rss['link'], rss['hashtag']))
 
@@ -125,19 +123,12 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG, format='%(message)s')
     try:
         main()
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         # Ctrl-c
-        raise e
-    except SystemExit, e:
-        # sys.exit()
-        raise e
-    except Exception, e:
-        print "error, unexcepted exception"
-        print str(e)
-        traceback.print_exc()
-        sys.exit(1)
-    else:
-        # Main function is done, exit cleanly
-        sys.exit(0)
+        sys.exit('aborted')
+    except Exception:
+        logging.exception('unexpected exception')
+        raise


### PR DESCRIPTION
this PR is built on top of #3, #4 and #5. it aims to cleanup the code by removing code duplication and ambiguities about how the default mode works.

to quote 3e9631a:

> this changes the default behavior to be a little less confusing: instead of tweeting just one RSS entry, it tweets the last RSS entries found, up to the one that was already recorded in the cache file or LIMIT is hit.
> 
> --all behavior isn't changed, although we refactored the code and help docs for the behavior to be a little more clear (that is, we skip the cache file)
>
> incidentally, we inject the docstring in the usage to clarify what this does

also, oldest posts are tweeted first now.