### PR TITLE
move more options out of the config file

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -9,6 +9,3 @@ cachefile=~/.cache/feed2tweet.dat
 
 [rss]
 uri=http://example.com/feed.xml
-
-[hashtaglist]
-several_words_hashtags_list=/dev/null

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -9,3 +9,6 @@ cachefile=~/.cache/feed2tweet.dat
 
 [rss]
 uri=http://example.com/feed.xml
+
+[hashtaglist]
+several_words_hashtags_list=severalwordshashtaglist.txt

--- a/feed2tweet
+++ b/feed2tweet
@@ -96,6 +96,12 @@ def main():
         options.rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(options.rss_uri)
 
+    if options.hashtaglist is None:
+        try:
+            options.hashtaglist = config.get('hashtaglist', 'several_words_hashtags_list')
+        except NoOptionError:
+            options.hashtaglist = False
+
     # lots of scary warnings about possible security risk using this method
     # but for local use I'd rather do this than a try-catch with open()
     if not os.path.isfile(options.cachefile):

--- a/feed2tweet
+++ b/feed2tweet
@@ -68,6 +68,8 @@ def main():
     parser.add_argument('-n', '--dry-run', dest='dryrun',
                         action='store_true', default=False,
                         help='Do not actually post tweets')
+    parser.add_argument('--hashtaglist', dest='hashtaglist'
+                        help='a list of hashtag to match')
     options = parser.parse_args()
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
@@ -76,8 +78,6 @@ def main():
                                              config.get('cache', 'cachefile')))
     rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(rss_uri)
-    severalwordshashtagfile = config.get('hashtaglist',
-                                         'several_words_hashtags_list')
 
     # lots of scary warnings about possible security risk using this method
     # but for local use I'd rather do this than a try-catch with open()
@@ -86,10 +86,11 @@ def main():
         cPickle.dump({'id': None}, open(cachefile, 'wb'), -1)
 
     cache = cPickle.load(open(cachefile))
-    severalwordshashtags = codecs.open(severalwordshashtagfile,
-                                       encoding='utf-8').readlines()
-    severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
-    entries = feed['entries'][0:options.limit]
+    if options.hashtaglist:
+        severalwordshashtags = codecs.open(options.hashtaglist,
+                                           encoding='utf-8').readlines()
+        severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
+        entries = feed['entries'][0:options.limit]
 
     cached = False
     for entry in entries:
@@ -103,13 +104,14 @@ def main():
             'summary': entry['summary'],
         }
         severalwordsinhashtag = False
-        prehashtags = entry['tags'][0]['term']
-        tmphashtags = entry['tags'][0]['term']
-        for element in severalwordshashtags:
-            if element in prehashtags:
-                severalwordsinhashtag = True
-                tmphashtags = prehashtags.replace(element,
-                                                  ''.join(element.split()))
+        if options.hashtaglist:
+            prehashtags = entry['tags'][0]['term']
+            tmphashtags = entry['tags'][0]['term']
+            for element in severalwordshashtags:
+                if element in prehashtags:
+                    severalwordsinhashtag = True
+                    tmphashtags = prehashtags.replace(element,
+                                                      ''.join(element.split()))
         if severalwordsinhashtag:
             tmphashtags = tmphashtags.replace("'", "")
             finalhashtags = tmphashtags.split(' ')

--- a/feed2tweet
+++ b/feed2tweet
@@ -65,32 +65,34 @@ def main():
                         help='tweet all RSS items, regardless of cache')
     parser.add_argument('-l', '--limit', dest='limit', default=10,
                         help='tweet only LIMIT items (default: %(default)s)')
+    parser.add_argument('--cachefile', dest='cachefile',
+                        default=os.path.join(os.getenv('XDG_CACHE_HOME', '~/.cache'), 'feed2tweet.dat'),
+                        help='location of the cache file (default: %(default)s)')
     parser.add_argument('-n', '--dry-run', dest='dryrun',
                         action='store_true', default=False,
                         help='Do not actually post tweets')
-    parser.add_argument('--hashtaglist', dest='hashtaglist'
+    parser.add_argument('--hashtaglist', dest='hashtaglist',
                         help='a list of hashtag to match')
+    parser.add_argument('rss_uri', help='the RSS feed URL to fetch items from')
     options = parser.parse_args()
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
         sys.exit('Could not read config file')
-    cachefile = os.path.expanduser(os.getenv('XDG_CACHE_HOME',
-                                             config.get('cache', 'cachefile')))
-    rss_uri = config.get('rss', 'uri')
-    feed = feedparser.parse(rss_uri)
+    options.cachefile = os.path.expanduser(options.cachefile)
+    feed = feedparser.parse(options.rss_uri)
 
     # lots of scary warnings about possible security risk using this method
     # but for local use I'd rather do this than a try-catch with open()
-    if not os.path.isfile(cachefile):
+    if not os.path.isfile(options.cachefile):
         # make a blank cache file
-        cPickle.dump({'id': None}, open(cachefile, 'wb'), -1)
+        cPickle.dump({'id': None}, open(options.cachefile, 'wb'), -1)
 
-    cache = cPickle.load(open(cachefile))
+    cache = cPickle.load(open(options.cachefile))
     if options.hashtaglist:
         severalwordshashtags = codecs.open(options.hashtaglist,
                                            encoding='utf-8').readlines()
         severalwordshashtags = [i.rstrip('\n') for i in severalwordshashtags]
-        entries = feed['entries'][0:options.limit]
+    entries = feed['entries'][0:options.limit]
 
     cached = False
     for entry in entries:
@@ -129,7 +131,7 @@ def main():
             # We keep the first feed in the cache, to use feed2tweet
             # in normal mode the next time
             if not cached:
-                cPickle.dump(rss, open(cachefile, 'wb'), -1)
+                cPickle.dump(rss, open(options.cachefile, 'wb'), -1)
                 cached = True
 
 

--- a/feed2tweet
+++ b/feed2tweet
@@ -66,7 +66,6 @@ def main():
     parser.add_argument('-l', '--limit', dest='limit', default=10,
                         help='tweet only LIMIT items (default: %(default)s)')
     parser.add_argument('--cachefile', dest='cachefile',
-                        default=os.path.join(os.getenv('XDG_CACHE_HOME', '~/.cache'), 'feed2tweet.dat'),
                         help='location of the cache file (default: %(default)s)')
     parser.add_argument('-n', '--dry-run', dest='dryrun',
                         action='store_true', default=False,
@@ -86,12 +85,14 @@ def main():
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
         sys.exit('Could not read config file')
-    cachefile = os.getenv('XDG_CACHE_HOME')
-    if cachefile is None:
-        cachefile = config.get('cache', 'cachefile')
-    else:
-        cachefile = os.path.join(cachefile, 'feed2tweet.dat')
-    cachefile = os.path.expanduser(cachefile)
+
+    if options.cachefile is None:
+        try:
+            options.cachefile = config.get('cache', 'cachefile')
+        except NoOptionError:
+            options.cachefile = os.path.join(os.getenv('XDG_CACHE_HOME', '~/.cache'), 'feed2tweet.dat')
+    options.cachefile = os.path.expanduser(options.cachefile)
+
     if options.rss_uri is None:
         options.rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(options.rss_uri)

--- a/feed2tweet
+++ b/feed2tweet
@@ -71,14 +71,29 @@ def main():
     parser.add_argument('-n', '--dry-run', dest='dryrun',
                         action='store_true', default=False,
                         help='Do not actually post tweets')
+    parser.add_argument('-v', '--verbose', '--info', dest='log_level',
+                        action='store_const', const='info', default='warning',
+                        help='enable informative (verbose) output, work on log level INFO')
+    parser.add_argument('-d', '--debug', dest='log_level',
+                        action='store_const', const='debug', default='warning',
+                        help='enable debug output, work on log level DEBUG')
     parser.add_argument('--hashtaglist', dest='hashtaglist',
                         help='a list of hashtag to match')
-    parser.add_argument('rss_uri', help='the RSS feed URL to fetch items from')
+    parser.add_argument('rss_uri', help='the RSS feed URL to fetch items from',
+                        nargs='?')
     options = parser.parse_args()
+    logging.basicConfig(level=options.log_level.upper(), format='%(message)s')
     config = SafeConfigParser()
     if not config.read(os.path.expanduser(options.config)):
         sys.exit('Could not read config file')
-    options.cachefile = os.path.expanduser(options.cachefile)
+    cachefile = os.getenv('XDG_CACHE_HOME')
+    if cachefile is None:
+        cachefile = config.get('cache', 'cachefile')
+    else:
+        cachefile = os.path.join(cachefile, 'feed2tweet.dat')
+    cachefile = os.path.expanduser(cachefile)
+    if options.rss_uri is None:
+        options.rss_uri = config.get('rss', 'uri')
     feed = feedparser.parse(options.rss_uri)
 
     # lots of scary warnings about possible security risk using this method
@@ -96,7 +111,9 @@ def main():
 
     cached = False
     for entry in entries:
+        logging.debug('found feed entry %s, %s', entry['id'], entry['title'])
         if not options.all and entry['id'] == cache['id']:
+            logging.debug('found known entry, stopped processing')
             break
 
         rss = {
@@ -136,7 +153,6 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG, format='%(message)s')
     try:
         main()
     except KeyboardInterrupt as e:


### PR DESCRIPTION
with this, all options but twitter secrets are out of the config file.

this is necessary to allow running multiple clients, on multiple feeds, with a shared twitter credentials file.

it is also necessary to make dynamic oauth easier to configure (#9).

this PR builds on top of #7 and #4.