### PR TITLE
properly catch configparser errors

### DIFF
--- a/feed2tweet
+++ b/feed2tweet
@@ -16,7 +16,7 @@
 
 """Checks an RSS feed and posts new entries to twitter."""
 
-from ConfigParser import SafeConfigParser
+from ConfigParser import SafeConfigParser, NoOptionError, NoSectionError
 from argparse import ArgumentParser
 import cPickle
 import codecs
@@ -89,7 +89,7 @@ def main():
     if options.cachefile is None:
         try:
             options.cachefile = config.get('cache', 'cachefile')
-        except NoOptionError:
+        except (NoOptionError, NoSectionError):
             options.cachefile = os.path.join(os.getenv('XDG_CACHE_HOME', '~/.cache'), 'feed2tweet.dat')
     options.cachefile = os.path.expanduser(options.cachefile)
 
@@ -100,7 +100,7 @@ def main():
     if options.hashtaglist is None:
         try:
             options.hashtaglist = config.get('hashtaglist', 'several_words_hashtags_list')
-        except NoOptionError:
+        except (NoOptionError, NoSectionError):
             options.hashtaglist = False
 
     # lots of scary warnings about possible security risk using this method


### PR DESCRIPTION
we were not importing the exception properly, probably a merge
error. we also were missing an exception, which can happen when the
config file is missing a whole section.