### PR TITLE
syslog support

### DIFF
--- a/feed2tweet/cliparse.py
+++ b/feed2tweet/cliparse.py
@@ -19,6 +19,7 @@
 # standard library imports
 from argparse import ArgumentParser
 import glob
+import logging
 import os.path
 import sys
 
@@ -61,6 +62,14 @@ class CliParse(object):
         parser.add_argument('-d', '--debug', dest='log_level',
                             action='store_const', const='debug', default='warning',
                             help='enable debug output, work on log level DEBUG')
+        levels = [i for i in logging._nameToLevel.keys()
+        if (type(i) == str and i != 'NOTSET')]
+        parser.add_argument('--syslog', nargs='?', default=None,
+                            type=str.upper, action='store',
+                            const='INFO', choices=levels,
+                            help="""log to syslog facility, default: no
+                            logging, INFO if --syslog is specified without
+                            argument""")
         parser.add_argument('--hashtaglist', dest='hashtaglist',
                             help='a list of hashtag to match')
         parser.add_argument('-p', '--populate-cache', action='store_true', default=False,


### PR DESCRIPTION
we need to configure the root logger in the DEBUG level otherwise the
--verbose level applies to syslog, which has its own level

when we do this, we also drop the default stdout handler, so we add it
back. if we wish, this could be sent to a logfile instead of stdout
there, but i chose to use just syslog for simplicity

this is more or less a reroll of #17.