### PR TITLE
automatically configure oauth access tokens

### DIFF
--- a/feed2tweet/cliparse.py
+++ b/feed2tweet/cliparse.py
@@ -66,6 +66,8 @@ class CliParse(object):
         parser.add_argument('-p', '--populate-cache', action='store_true', default=False,
                             dest='populate',
                             help='populate RSS entries in cache without actually posting them to Twitter')
+        parser.add_argument('-i', '--init', action='store_true', default=False,
+                            help='interactively reinitialize Twitter Oauth tokens')
         parser.add_argument('-r', '--rss', help='the RSS feed URL to fetch items from',
                             dest='rss_uri', metavar='http://...')
         parser.add_argument('--rss-sections', action='store_true', default=False,

--- a/feed2tweet/confparse.py
+++ b/feed2tweet/confparse.py
@@ -25,6 +25,8 @@ import sys
 # 3rd party library imports
 import feedparser
 
+from feed2tweet.tweetpost import TweetPost
+
 class ConfParse(object):
     '''ConfParse class'''
     def __init__(self, clioptions):
@@ -152,6 +154,10 @@ class ConfParse(object):
                 for field in ['user','pass','database']:
                     if field not in plugins[section]:
                         sys.exit('Parsing error for {field} in the [{section}] section: {field} is not defined'.format(field=field, section=section))
+
+            if self.clioptions.init and TweetPost.oauth_init(config):
+                with open(os.path.expanduser(pathtoconfig), 'w') as configfile:
+                    config.write(configfile)
 
             # storing results of the parsing
             if feeds:


### PR DESCRIPTION
we still rely on provided consumer keys and secrets, but at least now
access tokens are dynamically generated. we also add a --init option
to dynamically regenerate those.

the --init flag will look like it's configuring tokens multiple times
if you use the `-c ~/.config/feed2tweet.ini` option to work around
again, of course.

to test this, I used:

    feed2tweet.py -n --init

i haven't tested with a new post, but it should behave correctly as
well.

this is to help automating the creation of the config file. at some
point, feed2tweet would get an official consumer key that can then be
configured as a default in the app to remove the need for the user to
manually configure an app in twitter.

this is a reroll of #13, more or less.